### PR TITLE
修改增加类型标识枚举和限定词枚举

### DIFF
--- a/src/main/java/com/iot/protocol/iec104/enums/QualifiersEnum.java
+++ b/src/main/java/com/iot/protocol/iec104/enums/QualifiersEnum.java
@@ -52,11 +52,11 @@ public enum QualifiersEnum {
     /**
      * 设置命令限定词  选择预置参数 1000 0000
      */
-    prefabParameterQualifiers(null, 0x40),
+    prefabParameterQualifiers(null, 0x80),
     /**
      * 设置命令限定词  执行激活参数
      */
-    activationParameterQualifiers(null, 0x0F);
+    activationParameterQualifiers(null, 0x00);
 
     @Getter
     private byte value;
@@ -90,13 +90,23 @@ public enum QualifiersEnum {
                 && qualityQualifiers.getValue() == value) {
             qualifiersEnum = qualityQualifiers;
         }
-        if ((TypeIdentifierEnum.readOneParameter.equals(typeIdentifier)
+
+        //设置命令限定词 （参数预置）
+        if (TypeIdentifierEnum.readOneParameter.equals(typeIdentifier)
                 || TypeIdentifierEnum.readMultipleParameter.equals(typeIdentifier)
-                || TypeIdentifierEnum.prefabActivationOneParameter.equals(typeIdentifier)
-                || TypeIdentifierEnum.prefabActivationMultipleParameter.equals(typeIdentifier))
-                && qualityQualifiers.getValue() == value) {
-            qualifiersEnum = qualityQualifiers;
+                || TypeIdentifierEnum.prefabActivationNormalizedOneParameter.equals(typeIdentifier)
+                || TypeIdentifierEnum.prefabActivationScaledOneParameter.equals(typeIdentifier)
+                || TypeIdentifierEnum.prefabActivationFloatOneParameter.equals(typeIdentifier)
+                || TypeIdentifierEnum.prefabActivationNormalizedMultipleParameter.equals(typeIdentifier)
+                || TypeIdentifierEnum.prefabActivationScaledMultipleParameter.equals(typeIdentifier)
+                || TypeIdentifierEnum.prefabActivationFloatMultipleParameter.equals(typeIdentifier)){
+            if (prefabParameterQualifiers.getValue() == value) {
+                qualifiersEnum = prefabParameterQualifiers;
+            }else if(activationParameterQualifiers.getValue() == value){
+                qualifiersEnum = activationParameterQualifiers;
+            }
         }
+
         return qualifiersEnum;
     }
 }

--- a/src/main/java/com/iot/protocol/iec104/enums/TypeIdentifierEnum.java
+++ b/src/main/java/com/iot/protocol/iec104/enums/TypeIdentifierEnum.java
@@ -61,13 +61,29 @@ public enum TypeIdentifierEnum {
     readMultipleParameter(0x84, 4),
 
     /**
-     * 预置单个参数命令
+     * 预置单个参数命令(归一化值)
      */
-    prefabActivationOneParameter(0x30, 4),
+    prefabActivationNormalizedOneParameter(0x30, 2),
     /**
-     * 预置多个个参数
+     * 预置单个参数命令(标度化值)
      */
-    prefabActivationMultipleParameter(0x88, 4),
+    prefabActivationScaledOneParameter(0x30, 2),
+    /**
+     * 预置单个参数命令(浮点数值)
+     */
+    prefabActivationFloatOneParameter(0x30, 4),
+    /**
+     * 预置多个参数(归一化值)
+     */
+    prefabActivationNormalizedMultipleParameter(0x88, 2),
+    /**
+     * 预置多个参数(标度化值)
+     */
+    prefabActivationScaledMultipleParameter(0x89, 2),
+    /**
+     * 预置多个参数(浮点数值)
+     */
+    prefabActivationFloatMultipleParameter(0x8A, 4),
 
     /**
      * 初始化结束


### PR DESCRIPTION
1、修改类型标识枚举中的预设参数的值和长度，归一化和标度值为两位长度，浮点数为四位长度
2、修改限定词枚举中的执行预置参数和执行激活参数的值分别为1000 0000(0x80)和0000 0000(0x00)
3、修改限定词枚举中的getQualifiersEnum(TypeIdentifierEnum,byte)方法,增加设置命令限定词的判断条件